### PR TITLE
Check if user has forgotten to substitute their sdk key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 
 # Local environment settings
 .envrc
+
+# Vite temporary files.
+.vite/

--- a/src/feature-management/FeatureFlagsProvider.tsx
+++ b/src/feature-management/FeatureFlagsProvider.tsx
@@ -12,7 +12,6 @@ type Props = {
 
 export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
 
-
   const [flagState, setFlagState] = useState(useFeatureFlags())
 
   const initialised = React.useRef(false)
@@ -29,6 +28,12 @@ export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
     Rox.register('', flags)
 
     const initFeatureFlags = async() => {
+
+      // Easy to forget to insert your SDK key where shown above, so let's check & remind you!
+      if (sdkKey === '<INSERT YOUR SDK KEY HERE>') {
+        throw new Error("You haven't yet inserted your SDK Key into FeatureFlagsProvider.tsx! Feature Flag values will not update until you do so.\nPlease check the README.md for instructions.")
+      }
+
       await Rox.setup(sdkKey, {
         configurationFetchedHandler(fetcherResult: Rox.RoxFetcherResult) {
           if (fetcherResult.fetcherStatus === "APPLIED_FROM_NETWORK") {
@@ -42,7 +47,11 @@ export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
       setFlagState({...flagState, loading: false})
     }
 
-    initFeatureFlags()
+    initFeatureFlags().catch((e) => {
+      console.error(e.message)
+      window.alert(e.message)
+      setFlagState({...flagState, loading: false})
+    })
 
   }, [flagState])
 

--- a/src/feature-management/FeatureFlagsProvider.tsx
+++ b/src/feature-management/FeatureFlagsProvider.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
 
   const [flagState, setFlagState] = useState(useFeatureFlags())
+  const [error, setError] = useState<string | undefined>(undefined)
 
   const initialised = React.useRef(false)
 
@@ -31,7 +32,7 @@ export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
 
       // Easy to forget to insert your SDK key where shown above, so let's check & remind you!
       if (sdkKey === '<INSERT YOUR SDK KEY HERE>') {
-        throw new Error("You haven't yet inserted your SDK Key into FeatureFlagsProvider.tsx! Feature Flag values will not update until you do so.\nPlease check the README.md for instructions.")
+        throw new Error("You haven't yet inserted your SDK Key into FeatureFlagsProvider.tsx - the application below will not update until you do so. Please check the README.md for instructions.")
       }
 
       await Rox.setup(sdkKey, {
@@ -49,11 +50,19 @@ export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
 
     initFeatureFlags().catch((e) => {
       console.error(e.message)
-      window.alert(e.message)
+      setError(e.message)
       setFlagState({...flagState, loading: false})
     })
 
   }, [flagState])
 
-  return <FeatureFlagsContext.Provider value={flagState}>{children}</FeatureFlagsContext.Provider>;
+  return (
+    <FeatureFlagsContext.Provider value={flagState}>
+      {error && (
+        <h3 style={{color: 'red'}}>{error}</h3>
+      )}
+
+      {children}
+    </FeatureFlagsContext.Provider>
+  )
 }


### PR DESCRIPTION
Thank you @SamGrah for trying out the sample app... and immediately forgetting to insert your SDK Key! 😆 
Don't worry, I just did exactly the same earlier. Sorry for picking you out, but its a great point - _everyone_ will forget to do it and then either give up, or ask us why it doesn't work. Both of which are bad. This will just flash up a clear alert that nothing is going to change until you've done that, but then also allows the application to finish loading so you can see the page.