### PR TITLE
Fix typescript error when SDK key is set.

### DIFF
--- a/src/feature-management/FeatureFlagsProvider.tsx
+++ b/src/feature-management/FeatureFlagsProvider.tsx
@@ -31,6 +31,7 @@ export const FeatureFlagsProvider = ({children} : Props): React.ReactNode => {
     const initFeatureFlags = async() => {
 
       // Easy to forget to insert your SDK key where shown above, so let's check & remind you!
+      // @ts-ignore
       if (sdkKey === '<YOUR-SDK-KEY>') {
         throw new Error("You haven't yet inserted your SDK key into FeatureFlagsProvider.tsx - the application below will not update until you do so. Please check the README.adoc for instructions.")
       }


### PR DESCRIPTION
`src/feature-management/FeatureFlagsProvider.tsx:34:11 - error TS2367: This comparison appears to be unintentional because the types '"asdf"' and '"<YOUR-SDK-KEY>"' have no overlap.`