### PR TITLE
showMessage default to enabled.

### DIFF
--- a/src/feature-management/flags.ts
+++ b/src/feature-management/flags.ts
@@ -9,7 +9,7 @@ import {Flag, RoxString, RoxNumber} from "rox-browser";
 export const featureFlags = {
   // Boolean flag - Controls whether the message is displayed
   // Default: true (message shown)
-  showMessage: new Flag(),
+  showMessage: new Flag(true),
 
   // String flag - The message text to display
   // Default: 'This is the default message; try changing some flag values!'


### PR DESCRIPTION
It's hard to see the effect of flag changes (e.g. `ux.fontColor`) atm because the message is now shown by default; change to show the message by default.